### PR TITLE
prevent babel from traversing up directory tree

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "stage": 2
+  "stage": 2,
+  "breakConfig": true
 }


### PR DESCRIPTION
got fabricator throwing errors on scripts when I have a .babelrc in the project root (where my fabricator sits).

Babel will traverse up the project structure finding all .babelrc's.

adding `"breakConfig": true` prevents traversal: http://stackoverflow.com/questions/32540598/disable-babelrc-inheritance
